### PR TITLE
Make settings configurable

### DIFF
--- a/app/views/settings/_notify_settings.html.erb
+++ b/app/views/settings/_notify_settings.html.erb
@@ -1,0 +1,6 @@
+<h1>settings for the plugin will be here.....</h1>
+
+<p>
+  <label>Message broker URL</label>
+  <%= text_field_tag 'settings[broker_url]', @settings['broker_url'], :size => 50 %>(enter full URL including port if necessary)
+</p>

--- a/app/views/settings/_notify_settings.html.erb
+++ b/app/views/settings/_notify_settings.html.erb
@@ -1,6 +1,15 @@
-<h1>settings for the plugin will be here.....</h1>
+<%= t(:plugin_help) %>
 
 <p>
-  <label>Message broker URL</label>
-  <%= text_field_tag 'settings[broker_url]', @settings['broker_url'], :size => 50 %>(enter full URL including port if necessary)
+  <label><%= t(:broker_url) %></label>
+  <%= text_field_tag 'settings[broker_url]', @settings['broker_url'], :size => 50 %>
+  <br/><%= t(:broker_url_hint) %>
+</p>
+<p>
+  <label><%= t(:broker_login) %></label>
+  <%= text_field_tag 'settings[broker_login]', @settings['broker_login'], :size => 50 %>
+</p>
+<p>
+  <label><%= t(:broker_pwd) %></label>
+  <%= password_field_tag 'settings[broker_pwd]', @settings['broker_pwd'], :size => 50 %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
 "en":
-  broker_url: URL for the message broker
-  broker_login: Login for message broker
-  broker_pwd: Password for message broker
+  plugin_help: Please fill in the following fields so that Redmine can communicate with your message broker.
+  broker_url: URL
+  broker_url_hint: (e.g. http://localhost:8161/api/message/redmine?type=topic)
+  broker_login: Login
+  broker_pwd: Password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,4 @@
+"en":
+  broker_url: URL for the message broker
+  broker_login: Login for message broker
+  broker_pwd: Password for message broker

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,6 @@
 "fr":
-  broker_url: URL pour le broker de messages
-  broker_login: Identifiant pour le broker de messages
-  broker_pwd: Mot de passe pour le broker de messages
+  plugin_help: Merci de remplir ces champs afin de permettre à Redmine de communiquer avec le broker de messages.
+  broker_url: URL
+  broker_url_hint: (par exemple http://localhost:8161/api/message/redmine?type=topic)
+  broker_login: Identifiant
+  broker_pwd: Mot de passe

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,4 @@
+"fr":
+  broker_url: URL pour le broker de messages
+  broker_login: Identifiant pour le broker de messages
+  broker_pwd: Mot de passe pour le broker de messages

--- a/init.rb
+++ b/init.rb
@@ -5,8 +5,9 @@ Redmine::Plugin.register :notify do
   name 'Notify plugin'
   author 'mereth & jfix'
   description 'This is a plugin to send notifications to a message broker'
-  version '0.0.7'
+  version '0.1.0'
   url 'https://github.com/mereth/redmine-notify'
   author_url 'https://github.com/mereth'
-  settings :default => {'empty' => true}, :partial => 'settings/notify_settings'
+  settings :default => {'empty' => true},
+           :partial => 'settings/notify_settings'
 end

--- a/init.rb
+++ b/init.rb
@@ -8,4 +8,5 @@ Redmine::Plugin.register :notify do
   version '0.0.7'
   url 'https://github.com/mereth/redmine-notify'
   author_url 'https://github.com/mereth'
+  settings :default => {'empty' => true}, :partial => 'settings/notify_settings'
 end

--- a/lib/issues_hook_listener.rb
+++ b/lib/issues_hook_listener.rb
@@ -1,9 +1,6 @@
 
 class IssuesHookListener < Redmine::Hook::Listener
 
-  #@@broker_url = Setting[:plugin_notify][:broker_url]
-  @@broker_url = 'http://localhost:8161/api/message/redmine?type=topic'
-
   # catch new tickets
   def controller_issues_new_after_save(context = {})
     issue = context[:issue]
@@ -43,6 +40,12 @@ class IssuesHookListener < Redmine::Hook::Listener
 
   # method to send the event to the message broker
   def send_event_async(event)
+
+    # these variables are retrieved from the settings (see _notify_settings.html.erb)
+    @@broker_url = Setting.plugin_notify[:broker_url]
+    @@broker_login = Setting.plugin_notify[:broker_login]
+    @@broker_pwd = Setting.plugin_notify[:broker_pwd]
+
     Thread.new do
       uri = URI.parse(@@broker_url)
 
@@ -63,7 +66,7 @@ class IssuesHookListener < Redmine::Hook::Listener
         'Content-Type' => 'application/json',
         'Cookie' => cookiesString
       })
-      request.basic_auth("admin", "admin")
+      request.basic_auth(@@broker_login, @@broker_pwd)
       request.body = event.to_json
 
       # execute request

--- a/lib/issues_hook_listener.rb
+++ b/lib/issues_hook_listener.rb
@@ -1,8 +1,9 @@
 
 class IssuesHookListener < Redmine::Hook::Listener
-  
+
+  #@@broker_url = Setting[:plugin_notify][:broker_url]
   @@broker_url = 'http://localhost:8161/api/message/redmine?type=topic'
-  
+
   # catch new tickets
   def controller_issues_new_after_save(context = {})
     issue = context[:issue]
@@ -16,18 +17,18 @@ class IssuesHookListener < Redmine::Hook::Listener
 
     send_event_async(event)
   end
-  
+
   # catch ticket status changes
   def controller_issues_edit_after_save(context = {})
     issue = context[:issue]
     journal = context[:journal]
-    
+
     statusChange = journal.detail_for_attribute('status_id')
-    
+
     if statusChange.nil?
       return
     end
-    
+
     event = {
       :type => "change",
       :issue_id => issue.id,
@@ -36,7 +37,7 @@ class IssuesHookListener < Redmine::Hook::Listener
       :old_status_id => statusChange.old_value,
       :new_status_id => statusChange.value
     }
-    
+
     send_event_async(event)
   end
 
@@ -44,10 +45,10 @@ class IssuesHookListener < Redmine::Hook::Listener
   def send_event_async(event)
     Thread.new do
       uri = URI.parse(@@broker_url)
-      
+
       # load cookies store
       cookiesStore = PStore.new("notify.cookies.pstore", thread_safe = true)
-      
+
       # prepare cookie header
       cookiesString = ""
       cookiesStore.transaction(true) do
@@ -56,7 +57,7 @@ class IssuesHookListener < Redmine::Hook::Listener
           cookiesString = cookies.map{|k,v| "#{k}=#{v}"}.join(';')
         end
       end
-      
+
       # setup request
       request = Net::HTTP::Post.new(uri, {
         'Content-Type' => 'application/json',
@@ -64,11 +65,11 @@ class IssuesHookListener < Redmine::Hook::Listener
       })
       request.basic_auth("admin", "admin")
       request.body = event.to_json
-      
+
       # execute request
       http = Net::HTTP.new(uri.host, uri.port)
       response = http.request(request)
-      
+
       # save any new cookies
       newCookies = response.get_fields('Set-Cookie')
       if(newCookies)
@@ -77,12 +78,12 @@ class IssuesHookListener < Redmine::Hook::Listener
           if(!cookies)
             cookies = Hash.new
           end
-          
+
           newCookies.each do |cookie|
             cookie = ( cookie.split(';')[0] ).split('=', 2)
             cookies[ cookie[0] ] = cookie[1]
           end
-          
+
           cookiesStore[:cookies] = cookies
         end
       end


### PR DESCRIPTION
There is now a settings page for URL, login and password for the
message broker.

TODO: provide a means to test that the settings work as intended (have
a “test” button to make a call to the URL with the credentials provided)
